### PR TITLE
add loop to join cluster incase server isn't ready yet

### DIFF
--- a/griddb/start-griddb.sh
+++ b/griddb/start-griddb.sh
@@ -87,7 +87,7 @@ if [ "${1}" = 'griddb' ]; then
 
     # Start service
     gs_startnode -u $GRIDDB_USERNAME/$GRIDDB_PASSWORD -w
-    gs_joincluster -c $GRIDDB_CLUSTER_NAME -u $GRIDDB_USERNAME/$GRIDDB_PASSWORD -w
+    while ! gs_joincluster -u $GRIDDB_USERNAME/$GRIDDB_PASSWORD -c $GRIDDB_CLUSTER_NAME -w; do sleep 5; done &
 
     # Wait
     tail -f /var/lib/gridstore/log/gsstartup.log


### PR DESCRIPTION
this prevents the docker image from not crashing on start up as the join will fail if the server is recovering or just taking a while to start which is often the case on slower systems. 

more work should be completed so the image will start and restart with a persistent docker volume or bind mount. 